### PR TITLE
Migrate to provided.al2 lambda runtime

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,12 +13,12 @@ jobs:
     name: Style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.21
 
       - name: Format Check
         run: cd function && if [ $(gofmt -l -s . | grep -E -v '^vendor/' | tee /tmp/gofmt.txt
@@ -29,18 +29,18 @@ jobs:
     name: Functionality
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.21
 
       - name: Build
-        run: cd function && go build -v ./...
+        run: cd function && go build -v -tags lambda.norpc ./...
 
       - name: Test
-        run: cd function && go test -v -covermode="count" -coverprofile="/tmp/coverage.out"
+        run: cd function && go test -v -tags lambda.norpc -covermode="count" -coverprofile="/tmp/coverage.out"
 
       - name: Coverage Report
         run: cd function && go tool cover -func="/tmp/coverage.out"

--- a/aws-serverless/deploy.sh
+++ b/aws-serverless/deploy.sh
@@ -4,6 +4,7 @@ set -eou pipefail
 
 SAM_DIR="$(dirname "$0")"
 FUNC_DIR_RELATIVE="../function"
+APP="bootstrap"
 
 cd "${SAM_DIR}"
 
@@ -14,14 +15,14 @@ if [ ! -f "${SANITY}" ] ; then
 fi
 
 cd "${FUNC_DIR_RELATIVE}"
-GOOS=linux GOARCH=amd64 go build -o main
+GOOS=linux GOARCH=arm64 go build -tags lambda.norpc -o "${APP}"
+zip "${APP}.zip" "${APP}"
+rm -f "${APP}"
 cd -
 
-mv "${FUNC_DIR_RELATIVE}/main" ./
-sam deploy \
-  --no-confirm-changeset \
-  $@
-rm -f ./main
+mv "${FUNC_DIR_RELATIVE}/${APP}.zip" ./
+sam deploy --tags "project=cloudwatch_to_google_chat" $@
+rm -f "${APP}.zip"
 
 
 

--- a/aws-serverless/template.yml
+++ b/aws-serverless/template.yml
@@ -15,9 +15,11 @@ Resources:
   Function:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: main
-      Runtime: go1.x
-      CodeUri: .
+      Handler: bootstrap
+      Runtime: provided.al2
+      Architectures:
+        - arm64
+      CodeUri: ./bootstrap.zip
       FunctionName: !Join ['-', [!Ref AWS::StackName, lambda]]
       Description: *DESC
       Timeout: 30


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/